### PR TITLE
Adding NGINX for SSL certificate to docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,10 +6,9 @@ services:
   restart: always
   env_file:
    - .env
-  ports:
-   - "5000:5000"
   depends_on: 
    - mysql
+
  mysql:
   container_name: mysql
   image: mariadb
@@ -18,5 +17,22 @@ services:
    - .env
   volumes:
     - mydatabase:/var/lib/mysql
+
+ nginx: 
+  container_name: nginx
+  image: jonasal/nginx-certbot
+  restart: always
+  environment: 
+   - CERTBOT_EMAIL=name@example.com
+  ports:
+    - 80:80
+    - 443:443
+  volumes: 
+   - nginx_secrets:/etc/letsencrypt
+   - ./user_conf.d:/etc/nginx/user_conf.d
+  depends_on:
+   - myportfolio
+   
 volumes:
  mydatabase:
+ nginx_secrets:

--- a/user_conf.d/myportfolio.conf
+++ b/user_conf.d/myportfolio.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name gabrielaliera.duckdns.org;
+
+    if ($host = gabrielaliera.duckdns.org) {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name gabrielaliera.duckdns.org;
+
+    location / {
+        proxy_pass http://myportfolio:5000/;
+    }
+
+    #Load the certificate files
+    ssl_certificate /etc/letsencrypt/live/myportfolio/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/myportfolio/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/myportfolio/chain.pem;
+}


### PR DESCRIPTION
Changed `docker-compose.prod.yml` to include NGINX container

Added NGINX configuration file - `myportfolio.conf`
- Create a directory named `user_conf.d` under your project root directory. Create a `myportfolio.conf` inside this folder
- Line 1-8: Listen for HTTP traffic at port 80 and 301 redirect to HTTPS
- Line 11: Listen for HTTPS traffic at port 443
- Line 14-16: Reverse proxy traffic to our myportfolio container port 5000
- Line 19-21: Used by jonasal/nginx-certbot to generate certifications from LetsEncrypt

